### PR TITLE
Improve with key references

### DIFF
--- a/lib/dict_compactor.ex
+++ b/lib/dict_compactor.ex
@@ -1,16 +1,20 @@
 defmodule DictCompactor do
   @moduledoc """
-  Alternative JSON compactor using string dictionary approach.
+  Alternative JSON compactor using string dictionary approach with single-pass optimization.
 
   This implementation preserves the original data structure while extracting
   only strings and serialized atom strings into a separate dictionary for deduplication.
+  Uses a single-pass algorithm that simultaneously collects referenceable values and
+  replaces them with dictionary indices for optimal performance.
 
   ## Features
+  - Single-pass compaction algorithm - traverse data only once
   - No structure flattening - maintains original nesting
   - String dictionary for deduplication of strings and atom strings only
   - JSON-compatible serialization for atoms, tuples, structs
   - Both key and value references for strings
-  - Deterministic output with sorted keys
+  - Automatic deduplication with O(1) reference lookup
+  - Memory efficient - no intermediate data structures
 
   ## Output Format
 
@@ -22,35 +26,82 @@ defmodule DictCompactor do
         }
       }
 
+  ## Type Handling
+
+      # JSON-Compatible Serialization
+      atom: :hello → "_:hello"                    # String with prefix (referenceable)
+      tuple: {1, 2} → ["__t__", 1, 2]            # Array with marker (NOT referenceable)
+      struct: %User{name: "hi"} → %{"__struct__" => "Elixir.User", "name" => "hi"} (NOT referenceable)
+
+      # Referenceable Types (go in dictionary)
+      - Strings (always)
+      - Serialized atoms: "_:atom_name" 
+      - String map keys
+
+      # Non-Referenceable Types (preserved as-is)
+      - Numbers, booleans, nil
+      - Arrays (including tuple arrays)
+      - Objects (including struct objects)
+
   ## Examples
 
+      iex> # Simple map with string deduplication
       iex> input = %{"name" => "Alice", "role" => "admin"}
       iex> DictCompactor.compact(input)
       %{
         data: %{"0" => "1", "2" => "3"},
         dictionary: %{
           "0" => "name",
-          "1" => "Alice",
+          "1" => "Alice", 
           "2" => "role",
           "3" => "admin"
         }
       }
 
-      iex> # Complex types - JSON compatible
-      iex> input = %{atom: :hello, tuple: {1, 2}, user: %User{name: "Bob"}}
+      iex> # Atom keys and values with deduplication
+      iex> input = %{name: "Alice", role: :admin}
       iex> DictCompactor.compact(input)
       %{
-        data: %{"0" => "1", "2" => ["__t__", 1, 2], "3" => %{"4" => "5", "__struct__" => "6"}},
+        data: %{"0" => "1", "2" => "3"},
         dictionary: %{
-          "0" => "atom",
-          "1" => "_:hello",
-          "2" => "tuple",
-          "3" => "user",
-          "4" => "name",
-          "5" => "Bob",
-          "6" => "Elixir.User"
+          "0" => "_:name",
+          "1" => "Alice",
+          "2" => "_:role", 
+          "3" => "_:admin"
         }
       }
+
+      iex> # Complex types with JSON-compatible serialization
+      iex> input = %{atom: :hello, tuple: {1, :two}, struct: %User{name: "Bob"}}
+      iex> DictCompactor.compact(input)
+      %{
+        data: %{"0" => "1", "2" => ["__t__", 1, "3"], "4" => %{"5" => "6", "__struct__" => "7"}},
+        dictionary: %{
+          "0" => "_:atom",
+          "1" => "_:hello",
+          "2" => "_:tuple",
+          "3" => "_:two",
+          "4" => "_:struct", 
+          "5" => "_:name",
+          "6" => "Bob",
+          "7" => "Elixir.User"
+        }
+      }
+
+      iex> # Deduplication in action
+      iex> input = %{user1: %{name: "Alice"}, user2: %{name: "Alice"}}
+      iex> result = DictCompactor.compact(input)
+      iex> # "Alice" appears only once in dictionary despite being used twice
+      iex> Enum.count(Map.values(result.dictionary), fn v -> v == "Alice" end)
+      1
+
+  ## Performance
+
+  The single-pass algorithm provides significant performance benefits:
+  - **Time Complexity**: O(n) where n = total elements in data structure
+  - **Space Complexity**: O(u) where u = unique referenceable values
+  - **Memory Usage**: No intermediate collections, direct reference replacement
+  - **Deduplication**: O(1) lookup time for existing references
   """
 
   @type compacted_data :: %{
@@ -65,24 +116,25 @@ defmodule DictCompactor do
   @tuple_marker "__t__"
 
   @doc """
-  Compacts data using string dictionary approach.
+  Compacts data using single-pass string dictionary approach.
 
-  Extracts all referenceable values into a dictionary while preserving
-  the original structure with reference indices.
+  Simultaneously extracts referenceable values into a dictionary and replaces
+  them with reference indices in the original structure. Only strings and
+  serialized atom strings are referenced for optimal JSON compatibility.
+
+  ## Algorithm
+  - Single traversal of the data structure
+  - Immediate deduplication using O(1) hash map lookup
+  - Direct reference replacement during traversal
+  - Preserves original nesting and structure
+
+  ## Returns
+  A map with `:data` (structure with references) and `:dictionary` (index → value mapping).
   """
   @spec compact(any()) :: compacted_data()
   def compact(data) do
-    # Phase 1: Collect all referenceable values
-    {dictionary, _counter} = collect_values(data, %{}, 0)
-
-    # Phase 2: Build reverse lookup for value -> index
-    value_to_index =
-      dictionary
-      |> Enum.map(fn {index, value} -> {value, index} end)
-      |> Map.new()
-
-    # Phase 3: Replace values with references in data
-    referenced_data = replace_with_references(data, value_to_index)
+    # Single pass: collect values and replace with references simultaneously
+    {referenced_data, dictionary, _value_to_index, _counter} = compact_recursive(data, %{}, %{}, 0)
 
     %{
       data: referenced_data,
@@ -111,157 +163,107 @@ defmodule DictCompactor do
 
   def decompact(_), do: {:error, "Invalid compacted data format"}
 
-  # Phase 1: Collect all referenceable values with DFS
-  defp collect_values(data, dictionary, counter) do
+  # Single-pass recursive compaction
+  defp compact_recursive(data, dictionary, value_to_index, counter) do
     case data do
       # Handle maps (including structs)
       map when is_map(map) ->
-        collect_from_map(map, dictionary, counter)
+        compact_map(map, dictionary, value_to_index, counter)
 
       # Handle lists
       list when is_list(list) ->
-        collect_from_list(list, dictionary, counter)
-
-      # Handle tuples - serialize as JSON array (don't reference the tuple itself)
-      tuple when is_tuple(tuple) ->
-        tuple_list = Tuple.to_list(tuple)
-        collect_from_list(tuple_list, dictionary, counter)
-
-      # Handle atoms - serialize as string
-      atom when is_atom(atom) and not is_nil(atom) and not is_boolean(atom) ->
-        serialized = serialize_atom(atom)
-        add_to_dictionary_if_new(serialized, dictionary, counter)
-
-      # Handle strings
-      string when is_binary(string) ->
-        add_to_dictionary_if_new(string, dictionary, counter)
-
-      # Skip primitives (numbers, booleans, nil)
-      _ ->
-        {dictionary, counter}
-    end
-  end
-
-  defp collect_from_map(map, dictionary, counter) do
-    # For structs, add struct name to collection
-    {updated_dict, updated_counter} =
-      if is_struct(map) do
-        struct_name = Atom.to_string(map.__struct__)
-        add_to_dictionary_if_new(struct_name, dictionary, counter)
-      else
-        {dictionary, counter}
-      end
-
-    # Convert struct to map for processing
-    processed_map =
-      if is_struct(map) do
-        Map.from_struct(map)
-      else
-        map
-      end
-
-    # Process all keys and values
-    processed_map
-    |> Map.to_list()
-    |> Enum.reduce({updated_dict, updated_counter}, fn {key, value}, {acc_dict, acc_counter} ->
-      # Collect from key (convert atom keys to strings first)
-      string_key = if is_atom(key), do: serialize_atom(key), else: key
-      {dict_after_key, counter_after_key} = collect_values(string_key, acc_dict, acc_counter)
-
-      # Collect from value
-      collect_values(value, dict_after_key, counter_after_key)
-    end)
-  end
-
-  defp collect_from_list(list, dictionary, counter) do
-    Enum.reduce(list, {dictionary, counter}, fn item, {acc_dict, acc_counter} ->
-      collect_values(item, acc_dict, acc_counter)
-    end)
-  end
-
-  defp add_to_dictionary_if_new(value, dictionary, counter) do
-    # Check if value already exists in dictionary
-    existing_key =
-      Enum.find_value(dictionary, fn {key, dict_value} ->
-        if dict_value == value, do: key, else: nil
-      end)
-
-    if existing_key do
-      # Already exists, no change
-      {dictionary, counter}
-    else
-      key = Integer.to_string(counter)
-      updated_dict = Map.put(dictionary, key, value)
-      {updated_dict, counter + 1}
-    end
-  end
-
-  # Phase 2: Replace values with references
-  defp replace_with_references(data, value_to_index) do
-    case data do
-      # Handle maps (including structs)
-      map when is_map(map) ->
-        if is_struct(map) do
-          # Convert struct to map with __struct__ field
-          struct_name = Atom.to_string(map.__struct__)
-          struct_map = Map.from_struct(map)
-
-          processed_contents =
-            process_map_contents(struct_map, value_to_index)
-
-          referenced_struct_name = replace_with_references(struct_name, value_to_index)
-          Map.put(processed_contents, "__struct__", referenced_struct_name)
-        else
-          process_map_contents(map, value_to_index)
-        end
-
-      # Handle lists
-      list when is_list(list) ->
-        Enum.map(list, fn item ->
-          replace_with_references(item, value_to_index)
-        end)
+        compact_list(list, dictionary, value_to_index, counter)
 
       # Handle tuples - convert to JSON array format
       tuple when is_tuple(tuple) ->
         tuple_list = Tuple.to_list(tuple)
+        {referenced_list, updated_dict, updated_index, final_counter} = 
+          compact_list(tuple_list, dictionary, value_to_index, counter)
+        {[@tuple_marker | referenced_list], updated_dict, updated_index, final_counter}
 
-        referenced_list =
-          Enum.map(tuple_list, fn item ->
-            replace_with_references(item, value_to_index)
-          end)
-
-        [@tuple_marker | referenced_list]
-
-      # Handle atoms
+      # Handle atoms - serialize as string and reference
       atom when is_atom(atom) and not is_nil(atom) and not is_boolean(atom) ->
         serialized = serialize_atom(atom)
-        # Fallback to original if not found
-        Map.get(value_to_index, serialized, atom)
+        get_or_add_reference(serialized, dictionary, value_to_index, counter)
 
-      # Handle strings
+      # Handle strings - reference them
       string when is_binary(string) ->
-        # Fallback to original if not found
-        Map.get(value_to_index, string, string)
+        get_or_add_reference(string, dictionary, value_to_index, counter)
 
       # Return primitives as-is
       primitive ->
-        primitive
+        {primitive, dictionary, value_to_index, counter}
     end
   end
 
-  defp process_map_contents(map, value_to_index) do
-    map
-    |> Enum.map(fn {key, value} ->
-      # Process key - convert atoms to strings but preserve the atom in the key position for now
-      string_key = if is_atom(key), do: serialize_atom(key), else: key
-      referenced_key = replace_with_references(string_key, value_to_index)
+  defp compact_map(map, dictionary, value_to_index, counter) do
+    # Handle struct name first if it's a struct
+    {struct_dict, struct_index, struct_counter, struct_name_ref} = 
+      if is_struct(map) do
+        struct_name = Atom.to_string(map.__struct__)
+        {ref, dict, idx, cnt} = get_or_add_reference(struct_name, dictionary, value_to_index, counter)
+        {dict, idx, cnt, ref}
+      else
+        {dictionary, value_to_index, counter, nil}
+      end
 
-      # Process value
-      referenced_value = replace_with_references(value, value_to_index)
+    # Convert struct to map for processing
+    processed_map = if is_struct(map), do: Map.from_struct(map), else: map
 
-      {referenced_key, referenced_value}
-    end)
-    |> Map.new()
+    # Process all key-value pairs
+    {result_map, final_dict, final_index, final_counter} = 
+      processed_map
+      |> Enum.reduce({%{}, struct_dict, struct_index, struct_counter}, 
+        fn {key, value}, {acc_map, acc_dict, acc_index, acc_counter} ->
+          # Process key
+          string_key = if is_atom(key), do: serialize_atom(key), else: key
+          {referenced_key, dict_after_key, index_after_key, counter_after_key} = 
+            compact_recursive(string_key, acc_dict, acc_index, acc_counter)
+
+          # Process value
+          {referenced_value, dict_after_value, index_after_value, counter_after_value} = 
+            compact_recursive(value, dict_after_key, index_after_key, counter_after_key)
+
+          updated_map = Map.put(acc_map, referenced_key, referenced_value)
+          {updated_map, dict_after_value, index_after_value, counter_after_value}
+        end)
+
+    # Add __struct__ field if this was a struct
+    final_map = if struct_name_ref do
+      Map.put(result_map, "__struct__", struct_name_ref)
+    else
+      result_map
+    end
+
+    {final_map, final_dict, final_index, final_counter}
+  end
+
+  defp compact_list(list, dictionary, value_to_index, counter) do
+    {result_list, final_dict, final_index, final_counter} = 
+      list
+      |> Enum.reduce({[], dictionary, value_to_index, counter}, 
+        fn item, {acc_list, acc_dict, acc_index, acc_counter} ->
+          {referenced_item, dict_after_item, index_after_item, counter_after_item} = 
+            compact_recursive(item, acc_dict, acc_index, acc_counter)
+          {[referenced_item | acc_list], dict_after_item, index_after_item, counter_after_item}
+        end)
+
+    {Enum.reverse(result_list), final_dict, final_index, final_counter}
+  end
+
+  defp get_or_add_reference(value, dictionary, value_to_index, counter) do
+    case Map.get(value_to_index, value) do
+      nil ->
+        # Add new reference
+        key = Integer.to_string(counter)
+        updated_dict = Map.put(dictionary, key, value)
+        updated_index = Map.put(value_to_index, value, key)
+        {key, updated_dict, updated_index, counter + 1}
+      
+      existing_key ->
+        # Return existing reference
+        {existing_key, dictionary, value_to_index, counter}
+    end
   end
 
   # Phase 3: Restoration helpers
@@ -327,71 +329,6 @@ defmodule DictCompactor do
       String.to_existing_atom(atom_string)
     else
       value
-    end
-  end
-
-  defp deserialize_value(value) when is_list(value) do
-    IO.inspect(value)
-
-    case value do
-      [@tuple_marker | tuple_elements] ->
-        # Convert tuple array back to tuple
-        deserialized_elements = Enum.map(tuple_elements, &deserialize_value/1)
-        List.to_tuple(deserialized_elements)
-
-      list ->
-        Enum.map(list, &deserialize_value/1)
-    end
-  end
-
-  defp deserialize_value(value) when is_map(value) do
-    case Map.get(value, "__struct__") do
-      nil ->
-        # Regular map - convert string keys back to atoms if they were originally atoms
-        value
-        |> Enum.map(fn {k, v} ->
-          # Try to deserialize key - if it fails, keep as string
-          deserialized_key =
-            try do
-              deserialize_value(k)
-            rescue
-              _ -> k
-            end
-
-          {deserialized_key, deserialize_value(v)}
-        end)
-        |> Map.new()
-
-      struct_name_ref ->
-        # Reconstruct struct
-        struct_name = deserialize_value(struct_name_ref)
-        module = String.to_existing_atom(struct_name)
-        map_without_struct = Map.delete(value, "__struct__")
-
-        deserialized_map =
-          map_without_struct
-          |> Enum.map(fn {k, v} ->
-            # Convert string keys back to atoms for struct fields
-            atom_key =
-              if is_binary(k) do
-                try do
-                  deserialized_k = deserialize_value(k)
-
-                  if is_binary(deserialized_k),
-                    do: String.to_existing_atom(deserialized_k),
-                    else: deserialized_k
-                rescue
-                  _ -> if is_binary(k), do: String.to_existing_atom(k), else: k
-                end
-              else
-                k
-              end
-
-            {atom_key, deserialize_value(v)}
-          end)
-          |> Map.new()
-
-        struct!(module, deserialized_map)
     end
   end
 

--- a/lib/dict_compactor.ex
+++ b/lib/dict_compactor.ex
@@ -1,0 +1,404 @@
+defmodule DictCompactor do
+  @moduledoc """
+  Alternative JSON compactor using string dictionary approach.
+
+  This implementation preserves the original data structure while extracting
+  only strings and serialized atom strings into a separate dictionary for deduplication.
+
+  ## Features
+  - No structure flattening - maintains original nesting
+  - String dictionary for deduplication of strings and atom strings only
+  - JSON-compatible serialization for atoms, tuples, structs
+  - Both key and value references for strings
+  - Deterministic output with sorted keys
+
+  ## Output Format
+
+      %{
+        data: original_structure_with_references,
+        dictionary: %{
+          "0" => "actual_string_value_1",
+          "1" => "actual_string_value_2"
+        }
+      }
+
+  ## Examples
+
+      iex> input = %{"name" => "Alice", "role" => "admin"}
+      iex> DictCompactor.compact(input)
+      %{
+        data: %{"0" => "1", "2" => "3"},
+        dictionary: %{
+          "0" => "name",
+          "1" => "Alice",
+          "2" => "role",
+          "3" => "admin"
+        }
+      }
+
+      iex> # Complex types - JSON compatible
+      iex> input = %{atom: :hello, tuple: {1, 2}, user: %User{name: "Bob"}}
+      iex> DictCompactor.compact(input)
+      %{
+        data: %{"0" => "1", "2" => ["__t__", 1, 2], "3" => %{"4" => "5", "__struct__" => "6"}},
+        dictionary: %{
+          "0" => "atom",
+          "1" => "_:hello",
+          "2" => "tuple",
+          "3" => "user",
+          "4" => "name",
+          "5" => "Bob",
+          "6" => "Elixir.User"
+        }
+      }
+  """
+
+  @type compacted_data :: %{
+          data: any(),
+          dictionary: %{String.t() => String.t()}
+        }
+
+  @type decompact_result :: {:ok, any()} | {:error, String.t()}
+
+  # JSON-compatible serialization formats
+  @atom_prefix "_:"
+  @tuple_marker "__t__"
+
+  @doc """
+  Compacts data using string dictionary approach.
+
+  Extracts all referenceable values into a dictionary while preserving
+  the original structure with reference indices.
+  """
+  @spec compact(any()) :: compacted_data()
+  def compact(data) do
+    # Phase 1: Collect all referenceable values
+    {dictionary, _counter} = collect_values(data, %{}, 0)
+
+    # Phase 2: Build reverse lookup for value -> index
+    value_to_index =
+      dictionary
+      |> Enum.map(fn {index, value} -> {value, index} end)
+      |> Map.new()
+
+    # Phase 3: Replace values with references in data
+    referenced_data = replace_with_references(data, value_to_index)
+
+    %{
+      data: referenced_data,
+      dictionary: dictionary
+    }
+  end
+
+  @doc """
+  Decompacts data from dictionary format back to original structure.
+  """
+  @spec decompact(compacted_data()) :: decompact_result()
+  def decompact(%{data: data, dictionary: dictionary}) do
+    try do
+      # First deserialize all dictionary values
+      deserialized_dict =
+        deserialize_dictionary_values(dictionary)
+
+      # Then replace references in data structure
+      restored_data = replace_references_with_values(data, deserialized_dict)
+
+      {:ok, restored_data}
+    rescue
+      e -> {:error, "Decompaction failed: #{inspect(e)}"}
+    end
+  end
+
+  def decompact(_), do: {:error, "Invalid compacted data format"}
+
+  # Phase 1: Collect all referenceable values with DFS
+  defp collect_values(data, dictionary, counter) do
+    case data do
+      # Handle maps (including structs)
+      map when is_map(map) ->
+        collect_from_map(map, dictionary, counter)
+
+      # Handle lists
+      list when is_list(list) ->
+        collect_from_list(list, dictionary, counter)
+
+      # Handle tuples - serialize as JSON array (don't reference the tuple itself)
+      tuple when is_tuple(tuple) ->
+        tuple_list = Tuple.to_list(tuple)
+        collect_from_list(tuple_list, dictionary, counter)
+
+      # Handle atoms - serialize as string
+      atom when is_atom(atom) and not is_nil(atom) and not is_boolean(atom) ->
+        serialized = serialize_atom(atom)
+        add_to_dictionary_if_new(serialized, dictionary, counter)
+
+      # Handle strings
+      string when is_binary(string) ->
+        add_to_dictionary_if_new(string, dictionary, counter)
+
+      # Skip primitives (numbers, booleans, nil)
+      _ ->
+        {dictionary, counter}
+    end
+  end
+
+  defp collect_from_map(map, dictionary, counter) do
+    # For structs, add struct name to collection
+    {updated_dict, updated_counter} =
+      if is_struct(map) do
+        struct_name = Atom.to_string(map.__struct__)
+        add_to_dictionary_if_new(struct_name, dictionary, counter)
+      else
+        {dictionary, counter}
+      end
+
+    # Convert struct to map for processing
+    processed_map =
+      if is_struct(map) do
+        Map.from_struct(map)
+      else
+        map
+      end
+
+    # Process all keys and values
+    processed_map
+    |> Map.to_list()
+    |> Enum.reduce({updated_dict, updated_counter}, fn {key, value}, {acc_dict, acc_counter} ->
+      # Collect from key (convert atom keys to strings first)
+      string_key = if is_atom(key), do: serialize_atom(key), else: key
+      {dict_after_key, counter_after_key} = collect_values(string_key, acc_dict, acc_counter)
+
+      # Collect from value
+      collect_values(value, dict_after_key, counter_after_key)
+    end)
+  end
+
+  defp collect_from_list(list, dictionary, counter) do
+    Enum.reduce(list, {dictionary, counter}, fn item, {acc_dict, acc_counter} ->
+      collect_values(item, acc_dict, acc_counter)
+    end)
+  end
+
+  defp add_to_dictionary_if_new(value, dictionary, counter) do
+    # Check if value already exists in dictionary
+    existing_key =
+      Enum.find_value(dictionary, fn {key, dict_value} ->
+        if dict_value == value, do: key, else: nil
+      end)
+
+    if existing_key do
+      # Already exists, no change
+      {dictionary, counter}
+    else
+      key = Integer.to_string(counter)
+      updated_dict = Map.put(dictionary, key, value)
+      {updated_dict, counter + 1}
+    end
+  end
+
+  # Phase 2: Replace values with references
+  defp replace_with_references(data, value_to_index) do
+    case data do
+      # Handle maps (including structs)
+      map when is_map(map) ->
+        if is_struct(map) do
+          # Convert struct to map with __struct__ field
+          struct_name = Atom.to_string(map.__struct__)
+          struct_map = Map.from_struct(map)
+
+          processed_contents =
+            process_map_contents(struct_map, value_to_index)
+
+          referenced_struct_name = replace_with_references(struct_name, value_to_index)
+          Map.put(processed_contents, "__struct__", referenced_struct_name)
+        else
+          process_map_contents(map, value_to_index)
+        end
+
+      # Handle lists
+      list when is_list(list) ->
+        Enum.map(list, fn item ->
+          replace_with_references(item, value_to_index)
+        end)
+
+      # Handle tuples - convert to JSON array format
+      tuple when is_tuple(tuple) ->
+        tuple_list = Tuple.to_list(tuple)
+
+        referenced_list =
+          Enum.map(tuple_list, fn item ->
+            replace_with_references(item, value_to_index)
+          end)
+
+        [@tuple_marker | referenced_list]
+
+      # Handle atoms
+      atom when is_atom(atom) and not is_nil(atom) and not is_boolean(atom) ->
+        serialized = serialize_atom(atom)
+        # Fallback to original if not found
+        Map.get(value_to_index, serialized, atom)
+
+      # Handle strings
+      string when is_binary(string) ->
+        # Fallback to original if not found
+        Map.get(value_to_index, string, string)
+
+      # Return primitives as-is
+      primitive ->
+        primitive
+    end
+  end
+
+  defp process_map_contents(map, value_to_index) do
+    map
+    |> Enum.map(fn {key, value} ->
+      # Process key - convert atoms to strings but preserve the atom in the key position for now
+      string_key = if is_atom(key), do: serialize_atom(key), else: key
+      referenced_key = replace_with_references(string_key, value_to_index)
+
+      # Process value
+      referenced_value = replace_with_references(value, value_to_index)
+
+      {referenced_key, referenced_value}
+    end)
+    |> Map.new()
+  end
+
+  # Phase 3: Restoration helpers
+  defp replace_references_with_values(data, dictionary) do
+    case data do
+      # Handle reference strings
+      ref when is_binary(ref) ->
+        case Map.get(dictionary, ref) do
+          # Not a reference, return as-is
+          nil -> ref
+          # Found in dictionary, return the value
+          value -> value
+        end
+
+      # Handle maps
+      map when is_map(map) ->
+        result =
+          map
+          |> Enum.map(fn {key, value} ->
+            restored_key = replace_references_with_values(key, dictionary)
+            restored_value = replace_references_with_values(value, dictionary)
+            {restored_key, restored_value}
+          end)
+          |> Map.new()
+
+        try do
+          struct_name = result["__struct__"]
+          struct_module = String.to_existing_atom(struct_name)
+          struct(struct_module, result)
+        rescue
+          _ -> result
+        end
+
+      [@tuple_marker | tuple_data] ->
+        tuple_data
+        |> replace_references_with_values(dictionary)
+        |> List.to_tuple()
+
+      # Handle lists
+      list when is_list(list) ->
+        Enum.map(list, fn item ->
+          replace_references_with_values(item, dictionary)
+        end)
+
+      # Return primitives as-is
+      primitive ->
+        primitive
+    end
+  end
+
+  defp deserialize_dictionary_values(dictionary) do
+    dictionary
+    |> Enum.map(fn {key, value} ->
+      deserialized_value = deserialize_value(value)
+      {key, deserialized_value}
+    end)
+    |> Map.new()
+  end
+
+  defp deserialize_value(value) when is_binary(value) do
+    if String.starts_with?(value, @atom_prefix) do
+      atom_string = String.slice(value, String.length(@atom_prefix)..-1//1)
+      String.to_existing_atom(atom_string)
+    else
+      value
+    end
+  end
+
+  defp deserialize_value(value) when is_list(value) do
+    IO.inspect(value)
+
+    case value do
+      [@tuple_marker | tuple_elements] ->
+        # Convert tuple array back to tuple
+        deserialized_elements = Enum.map(tuple_elements, &deserialize_value/1)
+        List.to_tuple(deserialized_elements)
+
+      list ->
+        Enum.map(list, &deserialize_value/1)
+    end
+  end
+
+  defp deserialize_value(value) when is_map(value) do
+    case Map.get(value, "__struct__") do
+      nil ->
+        # Regular map - convert string keys back to atoms if they were originally atoms
+        value
+        |> Enum.map(fn {k, v} ->
+          # Try to deserialize key - if it fails, keep as string
+          deserialized_key =
+            try do
+              deserialize_value(k)
+            rescue
+              _ -> k
+            end
+
+          {deserialized_key, deserialize_value(v)}
+        end)
+        |> Map.new()
+
+      struct_name_ref ->
+        # Reconstruct struct
+        struct_name = deserialize_value(struct_name_ref)
+        module = String.to_existing_atom(struct_name)
+        map_without_struct = Map.delete(value, "__struct__")
+
+        deserialized_map =
+          map_without_struct
+          |> Enum.map(fn {k, v} ->
+            # Convert string keys back to atoms for struct fields
+            atom_key =
+              if is_binary(k) do
+                try do
+                  deserialized_k = deserialize_value(k)
+
+                  if is_binary(deserialized_k),
+                    do: String.to_existing_atom(deserialized_k),
+                    else: deserialized_k
+                rescue
+                  _ -> if is_binary(k), do: String.to_existing_atom(k), else: k
+                end
+              else
+                k
+              end
+
+            {atom_key, deserialize_value(v)}
+          end)
+          |> Map.new()
+
+        struct!(module, deserialized_map)
+    end
+  end
+
+  defp deserialize_value(value), do: value
+
+  # JSON-compatible serialization helpers
+  defp serialize_atom(atom) do
+    @atom_prefix <> Atom.to_string(atom)
+  end
+end

--- a/test/dict_compactor_test.exs
+++ b/test/dict_compactor_test.exs
@@ -1,0 +1,511 @@
+defmodule DictCompactorTest do
+  use ExUnit.Case
+
+  # Define a test struct
+  defmodule TestUser do
+    defstruct [:name, :age, :role]
+  end
+
+  describe "compact/1" do
+    test "handles primitive values without referencing" do
+      # Numbers, booleans, nil should not be referenced
+      assert DictCompactor.compact(42) == %{
+               data: 42,
+               dictionary: %{}
+             }
+
+      assert DictCompactor.compact(true) == %{
+               data: true,
+               dictionary: %{}
+             }
+
+      assert DictCompactor.compact(nil) == %{
+               data: nil,
+               dictionary: %{}
+             }
+    end
+
+    test "references strings in dictionary" do
+      result = DictCompactor.compact("hello")
+
+      assert result == %{
+               data: "0",
+               dictionary: %{"0" => "hello"}
+             }
+    end
+
+    test "references atom strings in dictionary" do
+      result = DictCompactor.compact(:hello)
+
+      assert result == %{
+               data: "0",
+               dictionary: %{"0" => "_:hello"}
+             }
+    end
+
+    test "does not reference boolean atoms" do
+      assert DictCompactor.compact(true) == %{
+               data: true,
+               dictionary: %{}
+             }
+
+      assert DictCompactor.compact(false) == %{
+               data: false,
+               dictionary: %{}
+             }
+
+      assert DictCompactor.compact(nil) == %{
+               data: nil,
+               dictionary: %{}
+             }
+    end
+
+    test "handles simple maps with string key and value references" do
+      input = %{"name" => "Alice", "role" => "admin"}
+      result = DictCompactor.compact(input)
+
+      assert result == %{
+               data: %{"0" => "1", "2" => "3"},
+               dictionary: %{
+                 "0" => "name",
+                 "1" => "Alice",
+                 "2" => "role",
+                 "3" => "admin"
+               }
+             }
+    end
+
+    test "handles maps with atom keys" do
+      input = %{name: "Alice", role: "admin"}
+      result = DictCompactor.compact(input)
+
+      # Atom keys converted to strings and referenced
+      assert result == %{
+               data: %{"0" => "1", "2" => "3"},
+               dictionary: %{
+                 "0" => "_:name",
+                 "1" => "Alice",
+                 "2" => "_:role",
+                 "3" => "admin"
+               }
+             }
+    end
+
+    test "handles lists without referencing the list itself" do
+      input = ["hello", 42, "world"]
+      result = DictCompactor.compact(input)
+
+      assert result == %{
+               data: ["0", 42, "1"],
+               dictionary: %{
+                 "0" => "hello",
+                 "1" => "world"
+               }
+             }
+    end
+
+    test "serializes tuples as JSON arrays without referencing the array" do
+      input = {1, "hello", :world}
+      result = DictCompactor.compact(input)
+
+      assert result == %{
+               data: ["__t__", 1, "0", "1"],
+               dictionary: %{
+                 "0" => "hello",
+                 "1" => "_:world"
+               }
+             }
+    end
+
+    test "serializes structs as JSON objects without referencing the object" do
+      input = %TestUser{name: "Alice", age: 30, role: :admin}
+      result = DictCompactor.compact(input)
+
+      assert result == %{
+               data: %{"__struct__" => "0", "1" => 30, "2" => "3", "4" => "5"},
+               dictionary: %{
+                 "0" => "Elixir.DictCompactorTest.TestUser",
+                 "1" => "_:age",
+                 "2" => "_:name",
+                 "3" => "Alice",
+                 "4" => "_:role",
+                 "5" => "_:admin"
+               }
+             }
+    end
+
+    test "deduplicates identical strings" do
+      input = %{
+        "user1" => %{"name" => "Alice", "role" => "admin"},
+        "user2" => %{"name" => "Alice", "role" => "user"}
+      }
+
+      result = DictCompactor.compact(input)
+
+      # "Alice" should appear only once in dictionary
+      alice_count =
+        result.dictionary
+        |> Map.values()
+        |> Enum.count(fn v -> v == "Alice" end)
+
+      assert alice_count == 1
+
+      # "name" should appear only once in dictionary
+      name_count =
+        result.dictionary
+        |> Map.values()
+        |> Enum.count(fn v -> v == "name" end)
+
+      assert name_count == 1
+    end
+
+    test "deduplicates identical atom strings" do
+      input = [:admin, :admin, :user, :admin]
+      result = DictCompactor.compact(input)
+
+      # "_:admin" should appear only once in dictionary
+      admin_count =
+        result.dictionary
+        |> Map.values()
+        |> Enum.count(fn v -> v == "_:admin" end)
+
+      assert admin_count == 1
+
+      assert result == %{
+               data: ["0", "0", "1", "0"],
+               dictionary: %{
+                 "0" => "_:admin",
+                 "1" => "_:user"
+               }
+             }
+    end
+
+    test "handles nested structures" do
+      input = %{
+        "config" => %{
+          "database" => %{"host" => "localhost", "port" => 5432},
+          "cache" => %{"host" => "localhost", "ttl" => 300}
+        }
+      }
+
+      result = DictCompactor.compact(input)
+
+      # "localhost" should be deduplicated
+      localhost_count =
+        result.dictionary
+        |> Map.values()
+        |> Enum.count(fn v -> v == "localhost" end)
+
+      assert localhost_count == 1
+
+      # "host" should be deduplicated
+      host_count =
+        result.dictionary
+        |> Map.values()
+        |> Enum.count(fn v -> v == "host" end)
+
+      assert host_count == 1
+    end
+
+    test "produces deterministic output" do
+      input = %{"b" => "second", "a" => "first", "c" => "third"}
+
+      result1 = DictCompactor.compact(input)
+      result2 = DictCompactor.compact(input)
+
+      assert result1 == result2
+    end
+
+    test "handles empty structures" do
+      assert DictCompactor.compact(%{}) == %{
+               data: %{},
+               dictionary: %{}
+             }
+
+      assert DictCompactor.compact([]) == %{
+               data: [],
+               dictionary: %{}
+             }
+    end
+  end
+
+  describe "decompact/1" do
+    test "handles primitive values" do
+      compacted = %{data: 42, dictionary: %{}}
+      assert DictCompactor.decompact(compacted) == {:ok, 42}
+
+      compacted = %{data: "hello", dictionary: %{}}
+      assert DictCompactor.decompact(compacted) == {:ok, "hello"}
+    end
+
+    test "decompacts simple string references" do
+      compacted = %{
+        data: "0",
+        dictionary: %{"0" => "hello"}
+      }
+
+      assert DictCompactor.decompact(compacted) == {:ok, "hello"}
+    end
+
+    test "decompacts atom string references" do
+      compacted = %{
+        data: "0",
+        dictionary: %{"0" => "_:hello"}
+      }
+
+      assert DictCompactor.decompact(compacted) == {:ok, :hello}
+    end
+
+    test "decompacts maps with string references" do
+      compacted = %{
+        data: %{"0" => "1", "2" => "3"},
+        dictionary: %{
+          "0" => "name",
+          "1" => "Alice",
+          "2" => "role",
+          "3" => "admin"
+        }
+      }
+
+      expected = %{"name" => "Alice", "role" => "admin"}
+      assert DictCompactor.decompact(compacted) == {:ok, expected}
+    end
+
+    test "decompacts tuple arrays back to tuples" do
+      compacted = %{
+        data: ["__t__", 1, "0", "1"],
+        dictionary: %{
+          "0" => "hello",
+          "1" => "_:world"
+        }
+      }
+
+      assert DictCompactor.decompact(compacted) == {:ok, {1, "hello", :world}}
+    end
+
+    test "decompacts struct objects back to structs" do
+      compacted = %{
+        data: %{
+          "0" => "1",
+          "2" => 30,
+          "3" => "4",
+          "__struct__" => "5"
+        },
+        dictionary: %{
+          "0" => "_:name",
+          "1" => "Alice",
+          "2" => "_:age",
+          "3" => "_:role",
+          "4" => "_:admin",
+          "5" => "Elixir.DictCompactorTest.TestUser"
+        }
+      }
+
+      expected = %TestUser{name: "Alice", age: 30, role: :admin}
+      assert DictCompactor.decompact(compacted) == {:ok, expected}
+    end
+
+    test "decompacts nested structures" do
+      compacted = %{
+        data: %{
+          "0" => %{"1" => "2", "3" => 5432},
+          "4" => %{"1" => "2", "5" => 300}
+        },
+        dictionary: %{
+          "0" => "database",
+          "1" => "host",
+          "2" => "localhost",
+          "3" => "port",
+          "4" => "cache",
+          "5" => "ttl"
+        }
+      }
+
+      expected = %{
+        "database" => %{"host" => "localhost", "port" => 5432},
+        "cache" => %{"host" => "localhost", "ttl" => 300}
+      }
+
+      assert DictCompactor.decompact(compacted) == {:ok, expected}
+    end
+
+    test "returns error for invalid input format" do
+      assert DictCompactor.decompact("not a map") == {:error, "Invalid compacted data format"}
+      assert DictCompactor.decompact(%{data: "test"}) == {:error, "Invalid compacted data format"}
+
+      assert DictCompactor.decompact(%{dictionary: %{}}) ==
+               {:error, "Invalid compacted data format"}
+    end
+
+    test "handles missing dictionary references gracefully" do
+      compacted = %{
+        # "99" doesn't exist in dictionary
+        data: %{"0" => "99"},
+        dictionary: %{"0" => "name"}
+      }
+
+      # Should return the reference as-is if not found in dictionary
+      assert DictCompactor.decompact(compacted) == {:ok, %{"name" => "99"}}
+    end
+  end
+
+  describe "round-trip testing" do
+    test "primitive round-trip" do
+      primitives = ["hello", :atom, 42, true, false, nil, 3.14]
+
+      Enum.each(primitives, fn original ->
+        compacted = DictCompactor.compact(original)
+        {:ok, restored} = DictCompactor.decompact(compacted)
+        assert restored == original
+      end)
+    end
+
+    test "simple map round-trip" do
+      original = %{"name" => "Alice", "age" => 30, role: :admin}
+
+      compacted = DictCompactor.compact(original)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == original
+    end
+
+    test "tuple round-trip" do
+      original = {1, "hello", :world, true, nil}
+
+      compacted = DictCompactor.compact(original)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == original
+    end
+
+    test "struct round-trip" do
+      original = %TestUser{name: "Bob", age: 25, role: :developer}
+
+      compacted = DictCompactor.compact(original)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == original
+    end
+
+    test "complex nested structure round-trip" do
+      original = %{
+        users: [
+          %TestUser{name: "Alice", age: 30, role: :admin},
+          %TestUser{name: "Bob", age: 25, role: :user}
+        ],
+        config: %{
+          database: %{host: "localhost", port: 5432},
+          cache: %{host: "localhost", ttl: 300}
+        },
+        metadata: {
+          :version,
+          "1.0",
+          [:feature_a, :feature_b],
+          %{enabled: true, debug: false}
+        }
+      }
+
+      compacted = DictCompactor.compact(original)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == original
+    end
+
+    test "deduplication preservation round-trip" do
+      # Create data with lots of duplication
+      shared_config = %{timeout: 30, retries: 3, host: "localhost"}
+
+      original = %{
+        service_a: shared_config,
+        service_b: shared_config,
+        service_c: %{timeout: 30, host: "localhost", debug: true}
+      }
+
+      compacted = DictCompactor.compact(original)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == original
+
+      # Verify deduplication happened
+      dict_values = Map.values(compacted.dictionary)
+      localhost_count = Enum.count(dict_values, fn v -> v == "localhost" end)
+      # "localhost" appears only once
+      assert localhost_count == 1
+    end
+
+    test "empty structures round-trip" do
+      empty_map = %{}
+      empty_list = []
+      empty_tuple = {}
+
+      assert {:ok, ^empty_map} =
+               empty_map |> DictCompactor.compact() |> DictCompactor.decompact()
+
+      assert {:ok, ^empty_list} =
+               empty_list |> DictCompactor.compact() |> DictCompactor.decompact()
+
+      assert {:ok, ^empty_tuple} =
+               empty_tuple |> DictCompactor.compact() |> DictCompactor.decompact()
+    end
+  end
+
+  describe "edge cases" do
+    test "handles very deeply nested structures" do
+      # Create 10-level deep nesting
+      deep_structure =
+        Enum.reduce(1..10, %{value: "deep"}, fn i, acc ->
+          %{"level_#{i}" => acc}
+        end)
+
+      compacted = DictCompactor.compact(deep_structure)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == deep_structure
+    end
+
+    test "handles large lists with duplication" do
+      # Create list with repeated values
+      large_list =
+        Enum.flat_map(1..50, fn i ->
+          ["item_#{rem(i, 5)}", :common_atom, i]
+        end)
+
+      compacted = DictCompactor.compact(large_list)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == large_list
+
+      # Verify deduplication
+      dict_values = Map.values(compacted.dictionary)
+      common_atom_count = Enum.count(dict_values, fn v -> v == "_:common_atom" end)
+      assert common_atom_count == 1
+    end
+
+    test "handles maps with string keys that look like indices" do
+      original = %{
+        "0" => "value_zero",
+        "1" => "value_one",
+        "10" => "value_ten",
+        "normal_key" => "normal_value"
+      }
+
+      compacted = DictCompactor.compact(original)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == original
+    end
+
+    test "handles mixed atom and string keys" do
+      original = %{
+        "string_key" => "string_value",
+        :another_atom => :atom_value,
+        atom_key: "atom_key_value"
+      }
+
+      compacted = DictCompactor.compact(original)
+      {:ok, restored} = DictCompactor.decompact(compacted)
+
+      assert restored == original
+    end
+  end
+end


### PR DESCRIPTION
## Summary by Sourcery

Enable field key deduplication in JsonCompactor, refactor its traversal to DFS, and streamline reference resolution for keys and values. Augment benchmarks and tests to validate the new behavior. Add a new DictCompactor module implementing a single-pass string dictionary compaction approach with full documentation and test coverage.

New Features:
- Deduplicate repeated map field keys in JsonCompactor through key referencing
- Switch JSON compaction traversal from breadth-first to depth-first in JsonCompactor
- Introduce DictCompactor module for single-pass string dictionary compaction

Enhancements:
- Simplify map and struct handling in JsonCompactor by inline key/value reference resolution
- Extend benchmarks in JsonCompactorBench with user-list scenarios and updated decompaction & round-trip metrics
- Revise JsonCompactor documentation and examples to illustrate field key deduplication

Documentation:
- Update JsonCompactor docs to describe new field key referencing feature
- Add usage examples and API documentation for DictCompactor module

Tests:
- Expand JsonCompactor tests to cover field key referencing and updated indices
- Add comprehensive test suite for DictCompactor covering primitives, maps, lists, tuples, structs, and edge cases